### PR TITLE
Feature: Friends helping friends!

### DIFF
--- a/cogs/plant_care_commands.py
+++ b/cogs/plant_care_commands.py
@@ -141,9 +141,10 @@ class PlantCareCommands(utils.Cog):
         their_your = {True: "your", False: "their"}.get(owner)
 
         # See if they can water this person's plant
-        if(not owner):
+        if not owner:
             given_key = await db("SELECT * FROM user_garden_access WHERE garden_owner=$1 AND garden_access=$2", user_id, waterer)
-            return self.get_water_plant_dict(f"You don't have access to <@{user_id}>'s garden!")
+            if not given_key:
+                return self.get_water_plant_dict(f"You don't have access to <@{user_id}>'s garden!")
 
         # See if they have a plant available
         plant_level_row = await db("SELECT * FROM plant_levels WHERE user_id=$1 AND LOWER(plant_name)=LOWER($2)", user_id, plant_name)

--- a/cogs/plant_care_commands.py
+++ b/cogs/plant_care_commands.py
@@ -144,6 +144,7 @@ class PlantCareCommands(utils.Cog):
         if not owner:
             given_key = await db("SELECT * FROM user_garden_access WHERE garden_owner=$1 AND garden_access=$2", user_id, waterer_id)
             if not given_key:
+                await db.disconnect()
                 return self.get_water_plant_dict(f"You don't have access to <@{user_id}>'s garden!")
 
         # See if they have a plant available

--- a/cogs/plant_care_commands.py
+++ b/cogs/plant_care_commands.py
@@ -151,7 +151,7 @@ class PlantCareCommands(utils.Cog):
         if not plant_level_row:
             await db.disconnect()
             shop_note = "Run the `shop` command to plant some new seeds, or `plants` to see the list of plants you have already!"
-            return self.get_water_plant_dict(f"{they_you} don't have a plant with the name **{plant_name}**!{shop_note if owner else ''}")
+            return self.get_water_plant_dict(f"{they_you.capitalize()} don't have a plant with the name **{plant_name}**! {shop_note if owner else ''}")
         plant_data = self.bot.plants[plant_level_row[0]['plant_type']]
 
         if owner:

--- a/cogs/user_commands.py
+++ b/cogs/user_commands.py
@@ -189,7 +189,10 @@ class UserCommands(utils.Cog):
                 uname = (username[1:] if username.startswith("@") else username).strip().split("#")[0]
                 # Try and figure out who it is
                 for key in key_owners:
-                    u = await ctx.bot.fetch_user(key['garden_access'])
+                    try:
+                        u = await ctx.bot.fetch_user(key['garden_access'])
+                    except discord.HTTPException:
+                        continue
                     if uname == u.name:
                         user = u
                         break

--- a/cogs/user_commands.py
+++ b/cogs/user_commands.py
@@ -147,8 +147,6 @@ class UserCommands(utils.Cog):
             
             return await ctx.send(embed=embed)
 
-
-
     @utils.command()
     @commands.bot_has_permissions(send_messages=True)
     async def givekey(self, ctx:utils.Context, user:discord.Member):

--- a/cogs/user_commands.py
+++ b/cogs/user_commands.py
@@ -192,6 +192,7 @@ class UserCommands(utils.Cog):
                     u = await ctx.bot.fetch_user(key['garden_access'])
                     if uname == u.name:
                         user = u
+                        break
             if not user:
                 raise commands.UserNotFound(username)
             

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -13,6 +13,8 @@ event_webhook_url = ""  # Some events will be posted via webhook to this url
         days = 3
     [plants.water_cooldown]  # The water command cooldown - this gets passed directly into a timedelta
         minutes = 15
+    [plants.guest_water_cooldown]  # The water command cooldown for watering someone else's plant
+        minutes = 60
     [plants.notification_time]
         days = 1
 

--- a/config/database.pgsql
+++ b/config/database.pgsql
@@ -68,6 +68,13 @@ CREATE TABLE IF NOT EXISTS user_available_plants(
 );
 
 
+CREATE TABLE IF NOT EXISTS user_garden_access(
+    garden_access BIGINT,
+    garden_owner BIGINT,
+    last_here TIMESTAMP
+);
+
+
 CREATE TABLE IF NOT EXISTS blacklisted_suggestion_users(
     user_id BIGINT PRIMARY KEY
 );

--- a/config/database.pgsql
+++ b/config/database.pgsql
@@ -70,8 +70,7 @@ CREATE TABLE IF NOT EXISTS user_available_plants(
 
 CREATE TABLE IF NOT EXISTS user_garden_access(
     garden_access BIGINT,
-    garden_owner BIGINT,
-    last_here TIMESTAMP
+    garden_owner BIGINT
 );
 
 

--- a/config/database.pgsql
+++ b/config/database.pgsql
@@ -70,7 +70,8 @@ CREATE TABLE IF NOT EXISTS user_available_plants(
 
 CREATE TABLE IF NOT EXISTS user_garden_access(
     garden_access BIGINT,
-    garden_owner BIGINT
+    garden_owner BIGINT,
+    PRIMARY KEY (garden_access, garden_owner)
 );
 
 


### PR DESCRIPTION
Just a start for the friends watering feature as discussed in #24.

As far as EXP goes: I've implemented the 80/20 split, every hour. 
Multipliers are calculated the same way as if the owner watered, with the exception of the 'voted' multiplier. It's based on the user watering.

There is currently no indicator that user received 80% of what they would've, and no indicator the owner received any EXP. 

New commands:
`p.keys` - Lists everyone who has a key to your garden
`p.givekey [user]` - Gives that user a key
`p.revokekey [username]` - Removes key

Updated:
`p.waterplant` - Now has an optional 'Discord user' arg, which is a friend's name.

I've also added a DB table to map garden owners and accessors

Curious to hear your thoughts, and if you'd like to see something changed, added, or adapted.