### PR TITLE
Extra alias for inventory command

### DIFF
--- a/cogs/user_commands.py
+++ b/cogs/user_commands.py
@@ -8,7 +8,7 @@ import voxelbotutils as utils
 
 class UserCommands(utils.Cog):
 
-    @utils.command(aliases=['experience', 'exp', 'points', 'inv'])
+    @utils.command(aliases=['experience', 'exp', 'points', 'inv', 'bal', 'balance'])
     @commands.bot_has_permissions(send_messages=True, embed_links=True)
     async def inventory(self, ctx:utils.Context, user:typing.Optional[discord.User]):
         """


### PR DESCRIPTION
I always type p.bal because I'm used to it in other bots. _I can't be that stupid right?_ At Least one other person must've done the same a few times. So this is basically like editing a wikipedia article to be right about a subject. Hopefully now I can view my stats without being reminded of my idiocy.