### PR TITLE
Modify icons in HTML head

### DIFF
--- a/website/templates/base.html.j2
+++ b/website/templates/base.html.j2
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="{{ static('main.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ static('checkout.css') }}">
     <link rel="icon" type="image/png" href="{{ static('flower_icon_192.png') }}">
+    <link rel="apple-touch-icon" sizes="192x192" href="{{ static('flower_icon_192.png') }}">
     <meta name="twitter:card" content="summary" />
     <meta property="og:title" content="{{ self.title() }}" />
     <meta property="og:description" content="{%- block ogdescription -%}Care for virtual plants right in your Discord server!{%- endblock ogdescription -%}" />

--- a/website/templates/base.html.j2
+++ b/website/templates/base.html.j2
@@ -7,11 +7,11 @@
     <link rel="stylesheet" type="text/css" href="https://jenil.github.io/bulmaswatch/darkly/bulmaswatch.min.css">
     <link rel="stylesheet" type="text/css" href="{{ static('main.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ static('checkout.css') }}">
-    <link rel="icon" type="image/png" href="https://cdn.discordapp.com/app-icons/731736201400418314/918df3b3669f3d7087c811c69cfee094.png?size=128">
+    <link rel="icon" type="image/png" href="{{ static('flower_icon_192.png') }}">
     <meta name="twitter:card" content="summary" />
     <meta property="og:title" content="{{ self.title() }}" />
     <meta property="og:description" content="{%- block ogdescription -%}Care for virtual plants right in your Discord server!{%- endblock ogdescription -%}" />
-    <meta property="og:image" content="https://cdn.discordapp.com/app-icons/731736201400418314/918df3b3669f3d7087c811c69cfee094.png?size=512" />
+    <meta property="og:image" content="{{ static('flower_icon_192.png') }}" />
     <link rel="manifest" href="{{ static('flower.webmanifest') }}">
     <script data-ad-client="ca-pub-5971485568613064" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-0P1FY0JX1V"></script>
@@ -27,7 +27,7 @@
 <nav class="navbar" role="navigation" aria-label="main navigation" style="margin-bottom: 15px;">
     <div class="navbar-brand">
         <a class="navbar-item" href="/">
-            <img src="https://cdn.discordapp.com/app-icons/731736201400418314/918df3b3669f3d7087c811c69cfee094.png?size=128" id="navbarBrandImage">
+            <img src="{{ static('flower_icon_192.png') }}" id="navbarBrandImage">
         </a>
         <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarMenu">
             <span aria-hidden="true"></span>


### PR DESCRIPTION
- The existing meta tags now use the locally hosted, static Flower icon instead of the Discord CDN URL
- A new meta tag has been added to support Apple devices